### PR TITLE
add dev_account for tootctl

### DIFF
--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -9,6 +9,7 @@ require_relative 'mastodon/settings_cli'
 require_relative 'mastodon/statuses_cli'
 require_relative 'mastodon/domains_cli'
 require_relative 'mastodon/version'
+require_relative 'mastodon/debug_accounts_cli'
 
 module Mastodon
   class CLI < Thor
@@ -36,6 +37,9 @@ module Mastodon
 
     desc 'domains SUBCOMMAND ...ARGS', 'Manage account domains'
     subcommand 'domains', Mastodon::DomainsCLI
+
+    desc "debug_accounts SUBCOMMAND ...ARGS", "Manage accounts for debug"
+    subcommand "debug_accounts", Mastodon::DebugAccountCLI
 
     map %w(--version -v) => :version
 

--- a/lib/mastodon/debug_accounts_cli.rb
+++ b/lib/mastodon/debug_accounts_cli.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require 'set'
+require_relative '../../config/boot'
+require_relative '../../config/environment'
+require_relative 'cli_helper'
+
+module Mastodon
+  class DebugAccountCLI < Thor
+    def self.exit_on_failure?
+      true
+    end
+
+    option :username, required: true
+    option :role, default: "user"
+    option :confirmed, default: true, type: :boolean
+    option :raw_password, required: true
+    desc "create", "Create a new user for debug"
+    long_desc <<-EOL
+        デバッグ用に新たなユーザを作成します。
+        バッチ処理などのために、ユーザネーム、パスワードのみでアカウントを量産することができます。
+        
+        !! 生のパスワードが流れるため、本番環境での利用は非推奨です。 !!
+        !! DANGER !! this task uses raw password. DONT USE PRODUCTION ENV! !!
+    EOL
+
+    def create()
+      account = Account.new(username: options[:username])
+      password = options[:raw_password]
+      email = "#{options[:username]}@example.com"
+      user = User.new(email: email, password: password, agreement: true, admin: options[:role] == "admin", moderator: options[:role] == "moderator", confirmed_at: Time.now.utc)
+
+      # 既存チェック
+      if Account.find_local(options[:username]).present?
+        say("#{options[:username]}はすでに存在します/スキップ")
+        return
+      end
+
+      account.suspended = false
+      user.account = account
+
+      if user.save
+        if options[:confirmed]
+          user.confirmed_at = nil
+          user.confirm!
+        end
+
+        say("#{options[:username]}を作成しました", :green)
+        say("mail: #{email}")
+        say("pswd: #{password}")
+
+      else
+        user.errors.to_h.each do |key, error|
+          say('Failure/Error: ', :red)
+          say(key)
+          say('    ' + error, :red)
+        end
+        exit(1)
+
+      end
+    end
+
+  end
+end


### PR DESCRIPTION
Howto:
$ RAILS_ENV=production bundle exec bin/tootctl debug_accounts create --username=USERNAME --raw-password=PASSWORD

**CAUTION: DONT USE PRODUCTION.**

tootctlに開発やテスト用のアカウントを楽に作るためのスクリプトを追加。上記のコマンドの場合：

> Mail:  USERNAME@example.com
> Pass: PASSWORD

で作成されます。生パスワードが流れるので本番環境での利用は非推奨です。